### PR TITLE
Make Precis installable

### DIFF
--- a/.github/workflows/test_builds.yml
+++ b/.github/workflows/test_builds.yml
@@ -1,0 +1,24 @@
+name: Test build
+
+on: [push]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install from setup.py
+        run: python setup.py install
+      - name: Run test scripts
+        working-directory: tests/
+        run: |
+          python loader_test.py
+          python ontquery_test.py
+          python template_test.py

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,23 @@
+from setuptools import find_packages, setup
+
+# Import long description from README
+with open("docs/README.md", "r", encoding="utf-8") as readme_file:
+    long_description = readme_file.read()
+
+# Import requirements from requirements.txt
+with open("requirements.txt", "r", encoding="utf-8") as requirements_file:
+    requirements_list = requirements_file.read().split("\n")[:-1]
+
+setup(
+    name="precis",
+    version="1.5.2",
+    author="Rukmal Weerawarana",
+    packages=find_packages(),
+    author_email="rukmal.weerawarana@gmail.com",
+    description="",
+    long_description=long_description,
+    url="https://github.com/rukmal/precis",
+    install_requires=requirements_list,
+    package_data={"": ["templates/", "precis_ontology.rdf"]},
+    python_requires=">=3.6"
+)


### PR DESCRIPTION
Make precis installable

- Add setup.py to enable pip-install from repository
- Add pipelines to check builds on all supported Python versions (>= 3.6)